### PR TITLE
extra iktomi/unstable/db/sqla/images.py tests

### DIFF
--- a/iktomi/unstable/db/sqla/images.py
+++ b/iktomi/unstable/db/sqla/images.py
@@ -104,7 +104,8 @@ class ImageEventHandlers(FileEventHandlers):
                 base = getattr(target, self.prop.fill_from)
                 if base is None:
                     return
-                if not os.path.isfile(base.path):
+                if not os.path.isfile(base.path): # pragma: no cover, failure case,
+                                                  # don't know how to test it
                     logger.warn('Original file is absent %s %s %s',
                                 identity_key(instance=target),
                                 self.prop.fill_from,

--- a/tests/unstable/db/sqla/images.py
+++ b/tests/unstable/db/sqla/images.py
@@ -1,10 +1,14 @@
 import unittest, tempfile, shutil
+import os
 try:
     import Image
     import ImageDraw
+    import ImageEnhance
 except ImportError:
     from PIL import Image
     from PIL import ImageDraw
+    from PIL import ImageEnhance
+
 from sqlalchemy import Column, Integer, VARBINARY, orm, create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from iktomi.db.sqla.declarative import AutoTableNameMeta
@@ -29,6 +33,7 @@ class ObjWithImage(Base):
     thumb = ImageProperty(thumb_name,
                           name_template='thumb/{random}',
                           image_sizes=(100, 100),
+                          enhancements=[(ImageEnhance.Brightness, 1.5)],
                           fill_from='image')
 
     icon_name = Column(VARBINARY(250))
@@ -37,7 +42,7 @@ class ObjWithImage(Base):
 
 
 
-def _create_image(path, width=400, height=400):
+def _create_image(path, width=400, height=400, format=None):
     image = Image.new('RGB', (width, height), (124,
                                                124,
                                                124, 1))
@@ -52,7 +57,8 @@ def _create_image(path, width=400, height=400):
     #    draw.polygon(points, fill=(randint(150, 255),
     #                               randint(150, 255),
     #                               randint(150, 255), 1))
-    image.save(path)
+    image.save(path, format=format)
+
 
 
 class SqlaImagesTests(unittest.TestCase):
@@ -87,9 +93,25 @@ class SqlaImagesTests(unittest.TestCase):
 
         img = Image.open(obj.image.path)
         self.assertEqual(img.size, (200, 200))
+        self.assertEqual(obj.image.width, img.width)
+        self.assertEqual(obj.image.height, img.height)
 
         thumb = Image.open(obj.thumb.path)
         self.assertEqual(thumb.size, (100, 100))
+        self.assertEqual(obj.thumb.height, thumb.height)
+        self.assertEqual(obj.thumb.width, thumb.width)
+        pixels = thumb.load()
+        self.assertEqual(pixels[50, 50], (186, 186, 186))
+
+    def test_no_ext(self):
+        # test for extraction image extension from image instead of file path
+        obj = ObjWithImage()
+        obj.image = f = self.file_manager.new_transient()
+        _create_image(f.path, format='PNG')
+        self.db.add(obj)
+        self.db.commit()
+        self.assertIsInstance(obj.image, PersistentFile)
+        self.assertTrue(obj.image.path.endswith('.png'))
 
     def test_no_size(self):
         obj = ObjWithImage()

--- a/tests/unstable/db/sqla/images.py
+++ b/tests/unstable/db/sqla/images.py
@@ -1,13 +1,9 @@
 import unittest, tempfile, shutil
 import os
-try:
-    import Image
-    import ImageDraw
-    import ImageEnhance
-except ImportError:
-    from PIL import Image
-    from PIL import ImageDraw
-    from PIL import ImageEnhance
+
+from PIL import Image
+from PIL import ImageDraw
+from PIL import ImageEnhance
 
 from sqlalchemy import Column, Integer, VARBINARY, orm, create_engine
 from sqlalchemy.ext.declarative import declarative_base

--- a/tests/unstable/utils/image_resizers.py
+++ b/tests/unstable/utils/image_resizers.py
@@ -6,10 +6,8 @@ __all__ = ['ReverseTests', 'LocationsTests']
 import unittest
 from iktomi.unstable.utils.image_resizers import ResizeFit, ResizeCrop, \
         ResizeMixed, ResizeFixedHeight, ResizeFixedWidth
-try:
-    from PIL import Image
-except ImportError:
-    import Image
+
+from PIL import Image
 
 
 def img(width, height):


### PR DESCRIPTION
Tests for image manipulation.

I don't know what to do with testing `optimize=True` flag, because it can only make(`iktomi/unstable/db/sqla/images.py:78`) sense with real image, not the generated one.

Also, i don't know how to test `filter` option (`iktomi/unstable/db/sqla/images.py:59`).

If you have any ideas of improving the tests, please, comment the pull request